### PR TITLE
Add GrammarReader to parse TextMate grammar files

### DIFF
--- a/core/src/main/kotlin/dev/textmate/grammar/raw/GrammarReader.kt
+++ b/core/src/main/kotlin/dev/textmate/grammar/raw/GrammarReader.kt
@@ -1,6 +1,8 @@
 package dev.textmate.grammar.raw
 
 import com.google.gson.Gson
+import com.google.gson.JsonIOException
+import com.google.gson.JsonSyntaxException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.Reader
@@ -15,16 +17,37 @@ object GrammarReader {
 
     private val gson: Gson = Gson()
 
+    /**
+     * Parses a TextMate grammar from a JSON string.
+     *
+     * @throws JsonSyntaxException if the JSON is malformed or does not match the expected structure
+     */
     fun readGrammar(json: String): RawGrammar {
         val grammar = gson.fromJson(json, RawGrammar::class.java)
         assignIds(grammar)
         return grammar
     }
 
+    /**
+     * Parses a TextMate grammar from an [InputStream].
+     *
+     * The caller is responsible for closing the [inputStream] after this method returns.
+     *
+     * @throws JsonSyntaxException if the JSON is malformed or does not match the expected structure
+     * @throws JsonIOException if reading from the stream fails
+     */
     fun readGrammar(inputStream: InputStream): RawGrammar {
         return readGrammar(InputStreamReader(inputStream, Charsets.UTF_8))
     }
 
+    /**
+     * Parses a TextMate grammar from a [Reader].
+     *
+     * The caller is responsible for closing the [reader] after this method returns.
+     *
+     * @throws JsonSyntaxException if the JSON is malformed or does not match the expected structure
+     * @throws JsonIOException if reading from the reader fails
+     */
     fun readGrammar(reader: Reader): RawGrammar {
         val grammar = gson.fromJson(reader, RawGrammar::class.java)
         assignIds(grammar)

--- a/core/src/main/kotlin/dev/textmate/grammar/raw/RawGrammar.kt
+++ b/core/src/main/kotlin/dev/textmate/grammar/raw/RawGrammar.kt
@@ -22,6 +22,8 @@ data class RawGrammar(
  * or just a patterns container.
  *
  * [id] is assigned post-parse by [GrammarReader] — it does not come from JSON.
+ * Because [id] is mutable, instances should not be placed in hash-based
+ * collections (e.g. [HashSet], [HashMap] keys) before ID assignment is complete.
  */
 data class RawRule(
     var id: Int? = null,

--- a/core/src/test/kotlin/dev/textmate/grammar/raw/GrammarReaderTest.kt
+++ b/core/src/test/kotlin/dev/textmate/grammar/raw/GrammarReaderTest.kt
@@ -6,14 +6,14 @@ import org.junit.Test
 class GrammarReaderTest {
 
     private fun loadGrammar(resourcePath: String): RawGrammar {
-        val stream = javaClass.classLoader.getResourceAsStream(resourcePath)
+        return javaClass.classLoader.getResourceAsStream(resourcePath)
+            ?.use { stream -> GrammarReader.readGrammar(stream) }
             ?: throw IllegalArgumentException("Resource not found: $resourcePath")
-        return GrammarReader.readGrammar(stream)
     }
 
     private fun loadGrammarAsString(resourcePath: String): RawGrammar {
         val json = javaClass.classLoader.getResourceAsStream(resourcePath)!!
-            .bufferedReader(Charsets.UTF_8).readText()
+            .use { it.bufferedReader(Charsets.UTF_8).readText() }
         return GrammarReader.readGrammar(json)
     }
 


### PR DESCRIPTION
## Summary
This PR introduces the `GrammarReader` class and supporting data models to parse TextMate grammar files (`.tmLanguage.json` format) into an in-memory representation. The implementation includes automatic ID assignment for all grammar rules to enable efficient rule tracking and reference resolution.

## Key Changes
- **RawGrammar.kt**: Added data classes to represent the structure of TextMate grammars:
  - `RawGrammar`: Top-level grammar container with scope name, patterns, repository, and metadata
  - `RawRule`: Individual grammar rules supporting match, begin/end, begin/while patterns, and nested structures
  - `RawCapture`: Capture group definitions with optional nested patterns

- **GrammarReader.kt**: Implemented grammar parsing with three overloaded methods:
  - `readGrammar(String)`: Parse from JSON string
  - `readGrammar(InputStream)`: Parse from input stream
  - `readGrammar(Reader)`: Parse from reader
  - Automatic post-parse ID assignment to all rules in the grammar tree using a simple counter

- **GrammarReaderTest.kt**: Comprehensive test suite covering:
  - Grammar loading and basic properties (scopeName, name, fileTypes)
  - Pattern and repository structure validation
  - Capture group deserialization with string keys
  - Special field handling (whilePattern, applyEndPatternLast, contentName)
  - ID uniqueness and positivity across the entire grammar tree
  - Multiple input format support (stream vs. string)

## Notable Implementation Details
- Uses GSON for JSON deserialization with `@SerializedName` annotation to handle the `while` keyword (reserved in Kotlin)
- ID assignment is performed recursively through all nested patterns, repositories, and capture groups
- All rule IDs are guaranteed to be unique and positive integers
- Supports complex nested grammar structures including injections and repository references

https://claude.ai/code/session_016mFxZLUM4Gui4TygxLDz7C