### PR TITLE
Add GitHub Actions CI, benchmark tracking, and README badges

### DIFF
--- a/.github/scripts/check_regression.py
+++ b/.github/scripts/check_regression.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+IQR-based benchmark regression detector for KotlinTextMate.
+
+Reads the data.js file produced by github-action-benchmark, analyzes the most
+recent data point against a rolling window of historical results, and exits
+with code 1 if a statistically significant regression is detected.
+
+Algorithm (for avgt mode — lower is better, regression = value increased):
+  1. Extract the last WINDOW_SIZE measurements per benchmark.
+  2. Current value = last entry; baseline = the rest.
+  3. Remove outliers from baseline outside [Q1 - 1.5*IQR, Q3 + 1.5*IQR].
+  4. Compute baseline median.
+  5. If current > baseline_median * (1 + THRESHOLD), flag as regression.
+  6. Skip benchmarks with fewer than MIN_HISTORY data points.
+
+Usage:
+  python check_regression.py <path-to-data.js> <suite-name>
+
+Exit codes:
+  0 — all benchmarks within acceptable range (or insufficient history)
+  1 — regression detected in one or more benchmarks
+  2 — usage error
+"""
+
+import json
+import os
+import statistics
+import sys
+
+WINDOW_SIZE = 20
+THRESHOLD = 0.20
+MIN_HISTORY = 10
+
+DATA_JS_PREFIX = "window.BENCHMARK_DATA = "
+
+
+def load_data_js(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    if content.startswith(DATA_JS_PREFIX):
+        content = content[len(DATA_JS_PREFIX) :]
+    return json.loads(content)
+
+
+def extract_history(entries: list[dict]) -> dict[str, list[float]]:
+    history: dict[str, list[float]] = {}
+    for entry in entries:
+        for bench in entry.get("benches", []):
+            history.setdefault(bench["name"], []).append(bench["value"])
+    return history
+
+
+def iqr_filter(values: list[float]) -> list[float]:
+    if len(values) < 4:
+        return list(values)
+    s = sorted(values)
+    n = len(s)
+    q1 = statistics.median(s[: n // 2])
+    q3 = statistics.median(s[(n + 1) // 2 :])
+    iqr = q3 - q1
+    lo = q1 - 1.5 * iqr
+    hi = q3 + 1.5 * iqr
+    return [v for v in values if lo <= v <= hi]
+
+
+def check_regressions(
+    history: dict[str, list[float]],
+) -> tuple[list[dict], list[dict]]:
+    results = []
+    regressions = []
+
+    for name, all_values in sorted(history.items()):
+        window = all_values[-WINDOW_SIZE:]
+        current = window[-1]
+
+        if len(window) < MIN_HISTORY:
+            results.append(
+                {
+                    "name": name,
+                    "current": current,
+                    "baseline": None,
+                    "ratio": None,
+                    "status": "SKIP",
+                    "reason": f"only {len(window)} data points (need {MIN_HISTORY})",
+                }
+            )
+            continue
+
+        baseline_window = window[:-1]
+        cleaned = iqr_filter(baseline_window)
+        if not cleaned:
+            cleaned = list(baseline_window)
+
+        baseline = statistics.median(cleaned)
+        if baseline <= 0:
+            results.append(
+                {
+                    "name": name,
+                    "current": current,
+                    "baseline": baseline,
+                    "ratio": None,
+                    "status": "SKIP",
+                    "reason": "baseline median is zero or negative",
+                }
+            )
+            continue
+
+        ratio = current / baseline
+        is_regression = ratio > 1.0 + THRESHOLD
+
+        entry = {
+            "name": name,
+            "current": current,
+            "baseline": baseline,
+            "ratio": ratio,
+            "status": "REGRESSION" if is_regression else "OK",
+        }
+        results.append(entry)
+        if is_regression:
+            regressions.append(entry)
+
+    return results, regressions
+
+
+def write_summary(results: list[dict], regressions: list[dict]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    lines = ["## Benchmark Regression Check", ""]
+
+    if regressions:
+        lines.append(f"**{len(regressions)} regression(s) detected.**")
+    else:
+        lines.append("All benchmarks within acceptable range.")
+
+    lines.extend(
+        [
+            "",
+            "| Benchmark | Current (ms/op) | Baseline (ms/op) | Ratio | Status |",
+            "|-----------|----------------:|------------------:|------:|--------|",
+        ]
+    )
+
+    for r in results:
+        name = r["name"].split(".")[-1]
+        current_str = f"{r['current']:.2f}"
+        if r["baseline"] is not None:
+            baseline_str = f"{r['baseline']:.2f}"
+        else:
+            baseline_str = "—"
+        if r["ratio"] is not None:
+            ratio_str = f"{r['ratio']:.2f}x"
+        else:
+            ratio_str = "—"
+        status = r["status"]
+        if "reason" in r:
+            status = f"{status} ({r['reason']})"
+        lines.append(
+            f"| {name} | {current_str} | {baseline_str} | {ratio_str} | {status} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            f"Window: {WINDOW_SIZE} runs, threshold: {THRESHOLD * 100:.0f}%, "
+            f"min history: {MIN_HISTORY}",
+        ]
+    )
+
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <data.js path> <suite name>", file=sys.stderr)
+        sys.exit(2)
+
+    data_js_path = sys.argv[1]
+    suite_name = sys.argv[2]
+
+    print(f"Loading benchmark data from {data_js_path}")
+    data = load_data_js(data_js_path)
+
+    entries_map = data.get("entries", {})
+    if suite_name not in entries_map:
+        available = list(entries_map.keys())
+        print(f"Suite '{suite_name}' not found. Available: {available}")
+        print("No history yet — skipping regression check.")
+        sys.exit(0)
+
+    entries = entries_map[suite_name]
+    print(f"Found {len(entries)} historical entries for '{suite_name}'")
+
+    history = extract_history(entries)
+    print(
+        f"Checking {len(history)} benchmarks "
+        f"(window={WINDOW_SIZE}, threshold={THRESHOLD * 100:.0f}%, "
+        f"min_history={MIN_HISTORY}):\n"
+    )
+
+    results, regressions = check_regressions(history)
+
+    for r in results:
+        if r["status"] == "SKIP":
+            print(f"  SKIP  {r['name']}: {r.get('reason', '')}")
+        else:
+            print(
+                f"  {r['status']:4s}  {r['name']}: "
+                f"current={r['current']:.4f} baseline={r['baseline']:.4f} "
+                f"ratio={r['ratio']:.2f}x"
+            )
+
+    write_summary(results, regressions)
+
+    if regressions:
+        print(f"\nREGRESSION DETECTED in {len(regressions)} benchmark(s):")
+        for r in regressions:
+            print(
+                f"  {r['name']}: {r['current']:.4f}ms vs "
+                f"baseline {r['baseline']:.4f}ms "
+                f"({r['ratio']:.2f}x, >{1.0 + THRESHOLD:.2f}x threshold)"
+            )
+        sys.exit(1)
+    else:
+        print("\nAll benchmarks within acceptable range.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,6 +36,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Check if baseline exists
+        id: baseline
+        run: |
+          if git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ── PR: smoke benchmark (advisory) ──────────────────────────────────
 
       - name: Run smoke benchmark
@@ -54,7 +63,7 @@ jobs:
           echo "file=$RESULT_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Compare smoke result
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: KotlinTextMate Benchmark
@@ -62,7 +71,7 @@ jobs:
           output-file-path: ${{ steps.smoke-result.outputs.file }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           save-data-file: false
-          skip-fetch-gh-pages: true
+          skip-fetch-gh-pages: false
           comment-always: true
           summary-always: true
           fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,6 +62,7 @@ jobs:
           output-file-path: ${{ steps.smoke-result.outputs.file }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           save-data-file: false
+          skip-fetch-gh-pages: true
           comment-always: true
           summary-always: true
           fail-on-alert: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,127 @@
+name: Benchmark
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: benchmark-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # ── PR: smoke benchmark (advisory) ──────────────────────────────────
+
+      - name: Run smoke benchmark
+        if: github.event_name == 'pull_request'
+        run: ./gradlew :benchmark:smokeBenchmark
+
+      - name: Find smoke result
+        if: github.event_name == 'pull_request'
+        id: smoke-result
+        run: |
+          RESULT_FILE=$(find benchmark/build/reports/benchmarks -name '*.json' -type f | head -1)
+          if [ -z "$RESULT_FILE" ]; then
+            echo "::error::No benchmark JSON found"
+            exit 1
+          fi
+          echo "file=$RESULT_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Compare smoke result
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: KotlinTextMate Benchmark
+          tool: jmh
+          output-file-path: ${{ steps.smoke-result.outputs.file }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          save-data-file: false
+          comment-always: true
+          summary-always: true
+          fail-on-alert: false
+          alert-threshold: "150%"
+
+      # ── Main: full benchmark (tracked + regression check) ──────────────
+
+      - name: Run full benchmark
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: ./gradlew :benchmark:benchmark
+
+      - name: Find full result
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: full-result
+        run: |
+          RESULT_FILE=$(find benchmark/build/reports/benchmarks -name '*.json' -type f | head -1)
+          if [ -z "$RESULT_FILE" ]; then
+            echo "::error::No benchmark JSON found"
+            exit 1
+          fi
+          echo "file=$RESULT_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Store full result
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: KotlinTextMate Benchmark
+          tool: jmh
+          output-file-path: ${{ steps.full-result.outputs.file }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          save-data-file: true
+          summary-always: true
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-threshold: "150%"
+          max-items-in-chart: 100
+
+      - name: Fetch benchmark history
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if git fetch origin gh-pages 2>/dev/null; then
+            git checkout origin/gh-pages -- dev/bench/data.js 2>/dev/null || echo "No data.js found on gh-pages yet"
+          else
+            echo "No gh-pages branch yet — skipping regression check"
+          fi
+
+      - name: Check for performance regression (IQR)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if [ -f dev/bench/data.js ]; then
+            python .github/scripts/check_regression.py dev/bench/data.js "KotlinTextMate Benchmark"
+          else
+            echo "No benchmark history found — skipping regression check"
+          fi
+
+      - name: Upload benchmark results
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: benchmark/build/reports/benchmarks/
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run core tests
+        run: ./gradlew :core:test
+
+      - name: Assemble Android modules
+        run: ./gradlew :compose-ui:assembleDebug :sample-app:assembleDebug
+
+      - name: Compile benchmarks
+        run: ./gradlew :benchmark:compileKotlin
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: test-results
+          path: core/build/reports/tests/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Hero](docs/images/kotlin-textmate-hero.png)
 
-<!-- TODO: CI, license, Maven Central badges once published -->
+[![CI](https://github.com/ivan-magda/kotlin-textmate/actions/workflows/ci.yml/badge.svg)](https://github.com/ivan-magda/kotlin-textmate/actions/workflows/ci.yml)
+[![Benchmark](https://github.com/ivan-magda/kotlin-textmate/actions/workflows/benchmark.yml/badge.svg)](https://github.com/ivan-magda/kotlin-textmate/actions/workflows/benchmark.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A Kotlin/JVM port of [vscode-textmate](https://github.com/microsoft/vscode-textmate) — TextMate grammar tokenizer for syntax highlighting on Android and JVM.
 

--- a/core/src/test/kotlin/dev/textmate/grammar/GrammarTest.kt
+++ b/core/src/test/kotlin/dev/textmate/grammar/GrammarTest.kt
@@ -182,7 +182,7 @@ class GrammarTest {
 
     @Test
     fun `Kotlin fun keyword and function name scoped correctly`() {
-        val ktGrammar = loadGrammar("grammars/Kotlin.tmLanguage.json")
+        val ktGrammar = loadGrammar("grammars/kotlin.tmLanguage.json")
         val result = ktGrammar.tokenizeLine("fun main(args: Array<String>)")
         assertTrue(
             "Should have keyword.hard.fun scope",
@@ -196,7 +196,7 @@ class GrammarTest {
 
     @Test
     fun `Kotlin generic function retokenizes type parameters`() {
-        val ktGrammar = loadGrammar("grammars/Kotlin.tmLanguage.json")
+        val ktGrammar = loadGrammar("grammars/kotlin.tmLanguage.json")
         val result = ktGrammar.tokenizeLine("fun <T> test()")
         assertTrue(
             "Should have type parameter scope from retokenization",
@@ -210,7 +210,7 @@ class GrammarTest {
 
     @Test
     fun `Kotlin function tokens cover entire line`() {
-        val ktGrammar = loadGrammar("grammars/Kotlin.tmLanguage.json")
+        val ktGrammar = loadGrammar("grammars/kotlin.tmLanguage.json")
         val line = "fun main(args: Array<String>)"
         val result = ktGrammar.tokenizeLine(line)
         val tokens = result.tokens
@@ -308,7 +308,7 @@ class GrammarTest {
 
     @Test
     fun `Kotlin multiline string carries state across lines`() {
-        val ktGrammar = loadGrammar("grammars/Kotlin.tmLanguage.json")
+        val ktGrammar = loadGrammar("grammars/kotlin.tmLanguage.json")
 
         val r1 = ktGrammar.tokenizeLine("val s = \"\"\"")
         assertTrue(


### PR DESCRIPTION
## Summary

- **`ci.yml`** — Build & test on every push/PR: core tests, Android module compilation (`assembleDebug`), benchmark compilation check. Uploads test results as artifact on failure.
- **`benchmark.yml`** — Performance tracking with two paths:
  - **PRs:** smoke benchmark (~1 min), advisory comparison comment via `github-action-benchmark`, never blocks merge
  - **Main:** full benchmark (~8-10 min), stores results to `gh-pages` branch, IQR-based regression detection (20% threshold over rolling 20-run median), fails workflow on regression
- **`check_regression.py`** — IQR outlier filtering + median baseline regression detector. Writes markdown summary to `GITHUB_STEP_SUMMARY`. Skips gracefully with <10 historical data points.
- **README badges** — CI status, Benchmark status, MIT License

Dashboard will be available at `https://ivan-magda.github.io/kotlin-textmate/dev/bench/` once GitHub Pages is enabled on the `gh-pages` branch (created automatically on first main-branch benchmark run).

## Test plan

- [x] CI workflow triggers on this PR and passes (core tests, Android assemble, benchmark compile)
- [ ] Benchmark workflow triggers on this PR and runs smoke benchmark
- [ ] After merge: full benchmark runs on main, pushes to `gh-pages`, IQR script prints "SKIP" (insufficient history)
- [ ] README badges render correctly
- [ ] Enable GitHub Pages (Settings → Pages → Source: `gh-pages` branch) after first main benchmark run

Closes #26