### PR TITLE
Fix 27 Dependabot alerts: pin build-time AGP buildscript transitives to patched versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,37 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
+buildscript {
+    // Force patched versions of build-time-only AGP buildscript transitive dependencies (Dependabot alerts).
+    // These are build tooling (aapt2/bundletool/apksig/analytics-grpc) — NOT shipped in published core/compose-ui artifacts or the app runtime.
+    configurations.classpath {
+        resolutionStrategy {
+            force(
+                "io.netty:netty-buffer:4.1.132.Final",
+                "io.netty:netty-codec:4.1.132.Final",
+                "io.netty:netty-codec-http:4.1.132.Final",
+                "io.netty:netty-codec-http2:4.1.132.Final",
+                "io.netty:netty-codec-socks:4.1.132.Final",
+                "io.netty:netty-common:4.1.132.Final",
+                "io.netty:netty-handler:4.1.132.Final",
+                "io.netty:netty-handler-proxy:4.1.132.Final",
+                "io.netty:netty-resolver:4.1.132.Final",
+                "io.netty:netty-transport:4.1.132.Final",
+                "io.netty:netty-transport-native-unix-common:4.1.132.Final",
+                "org.bouncycastle:bcprov-jdk18on:1.84",
+                "org.bouncycastle:bcpkix-jdk18on:1.84",
+                "org.bouncycastle:bcutil-jdk18on:1.84",
+                "com.google.protobuf:protobuf-java:3.25.5",
+                "com.google.protobuf:protobuf-java-util:3.25.5",
+                "commons-io:commons-io:2.15.1", // >=2.14.0 patches CVE-2024-47554; 2.15.1 is the highest already on the classpath (avoids a downgrade)
+                "org.apache.commons:commons-compress:1.26.0",
+                "org.bitbucket.b_c:jose4j:0.9.6",
+                "org.jdom:jdom2:2.0.6.1",
+            )
+        }
+    }
+}
+
 // Detekt needs AGP/KGP classes on the root classpath to configure Android module tasks.
 plugins {
     alias(libs.plugins.android.application) apply false


### PR DESCRIPTION
## What

All 27 open Dependabot alerts are **transitive dependencies of the Android Gradle Plugin's buildscript classpath** (`com.android.application/library:8.7.3` → `com.android.tools.build:gradle:8.7.3` → bundletool / apksig / sdklib / analytics-grpc). They are **build tooling only** — they do not ship in the published `core`/`compose-ui` artifacts or in the sample app's runtime.

This pins each flagged package to its patched version via a `buildscript { configurations.classpath { resolutionStrategy.force(...) } }` block in the root build, which only affects the build classpath.

## Versions

| Package | Before | After |
|---|---|---|
| `io.netty:*` (11 modules) | 4.1.93.Final | 4.1.132.Final |
| `org.bouncycastle:bc{prov,pkix,util}-jdk18on` | 1.77 | 1.84 |
| `com.google.protobuf:protobuf-java{,-util}` | 3.22.3 | 3.25.5 |
| `commons-io:commons-io` | 2.13.0 | 2.15.1 |
| `org.apache.commons:commons-compress` | 1.21 | 1.26.0 |
| `org.bitbucket.b_c:jose4j` | 0.9.5 | 0.9.6 |
| `org.jdom:jdom2` | 2.0.6 | 2.0.6.1 |

Every force is an upgrade. `commons-io` is pinned to `2.15.1` — the highest version already on the classpath — so it clears CVE-2024-47554 without downgrading any build-tool dependency.

## Verification

- `./gradlew build` (unit tests + Android `assembleDebug`/`assembleRelease`, which exercise aapt2/bundletool/apksig with the forced protobuf) — **passes**.
- `./gradlew buildEnvironment` confirms every flagged module resolves to its patched version, with no vulnerable remnants.
- `:core:test` — 364 tests, 0 failures.

Should close all 27 alerts once Dependabot re-scans the branch.
