### PR TITLE
Scope Dependabot to published runtime deps (stop auditing build-time AGP tooling)

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,53 @@
+name: Dependency Submission
+
+# Submits the dependency graph that Dependabot audits.
+#
+# This project publishes two libraries (:core, :compose-ui). Only the dependencies
+# on their runtime classpaths actually reach consumers. The rest of the Gradle graph
+# is build-time tooling — the Android Gradle Plugin and its transitive stack
+# (bundletool, apksig, lint, the Unified Test Platform, grpc-netty, bouncycastle,
+# protobuf, jackson, woodstox, okhttp, ...). None of it ships in the published
+# artifacts or runs for users.
+#
+# GitHub's managed "Automatic Dependency Submission" submits the *entire* graph, which
+# floods Dependabot with alerts for that build-time tooling. This workflow replaces it
+# with a graph scoped to what we actually ship, so Dependabot tracks real consumer-facing
+# risk and still catches future vulnerabilities in joni / gson / Compose / etc.
+#
+# NOTE: For this to take effect, disable the managed submission at
+#   Settings → Advanced Security (Code security) → Automatic dependency submission.
+# Otherwise its full-graph snapshot is merged with this one and the tooling noise remains.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependency-submission-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    name: Submit dependency graph
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Submit dependency graph (published runtime deps only)
+        uses: gradle/actions/dependency-submission@v5
+        env:
+          # Only the published libraries, and only their runtime classpaths
+          # (:core -> runtimeClasspath, :compose-ui -> releaseRuntimeClasspath).
+          DEPENDENCY_GRAPH_INCLUDE_PROJECTS: "^(:core|:compose-ui)$"
+          DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: "^(runtimeClasspath|releaseRuntimeClasspath)$"


### PR DESCRIPTION
## Problem

Every Dependabot alert this repo has received (27, then 29 after the last graph refresh) is a **build-time tooling transitive**, not a dependency that ships to anyone. They come from the Android Gradle Plugin and its stack: `bundletool`, `apksig`, `sdklib`, lint, the Unified Test Platform, and their transitives — `grpc-netty`, `bouncycastle`, `protobuf`, `jackson`, `woodstox`, `okhttp`, `commons-*`, `jdom2`, `jose4j`, …

GitHub's managed **Automatic Dependency Submission** submits the *entire* resolved Gradle graph (every project, every configuration), so Dependabot ends up auditing all of that build tooling. For a published library that's pure noise — and it's a moving target, since each AGP/lint config the submission resolves drags in more.

The earlier buildscript `force(...)` workaround (#34) could only reach the **buildscript classpath**, so it fixed 13 alerts and left the rest (they live in project tooling configs it can't touch).

## Fix

Audit **what actually ships**. This adds a dependency-submission workflow scoped to the published libraries' runtime classpaths:

- `:core` → `runtimeClasspath`
- `:compose-ui` → `releaseRuntimeClasspath`

Those resolve to exactly the consumer-facing set — `kotlin-stdlib`, `joni`, `jcodings`, `gson`, and Compose — **none** of the flagged tooling (verified locally: 0 matches for netty/bouncycastle/protobuf/jackson/woodstox/okhttp/commons-*/jdom/jose4j). Real future vulnerabilities in those shipped deps are still caught; build-time noise stops at the source.

```
DEPENDENCY_GRAPH_INCLUDE_PROJECTS:       ^(:core|:compose-ui)$
DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: ^(runtimeClasspath|releaseRuntimeClasspath)$
```

## Required activation step

The managed submission can't be scoped, so it has to be turned off or its full-graph snapshot merges with this one and the noise remains:

> **Settings → Advanced Security (Code security) → Automatic dependency submission → Disable**

After that, the next push to `main` runs this workflow; the build-tool alerts clear because they're no longer in the submitted graph. (`workflow_dispatch` is enabled, so it can also be run on demand from the Actions tab.)

## Follow-up

Once the scoped graph is verified clean, the `buildscript { … force(…) }` block from #34 is redundant — the buildscript classpath is no longer submitted — and can be removed. It's harmless to keep until then, so this PR leaves it in place to avoid any regression window.
