### PR TITLE
Remove redundant buildscript force block (revert #34)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,37 +2,6 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
-buildscript {
-    // Force patched versions of build-time-only AGP buildscript transitive dependencies (Dependabot alerts).
-    // These are build tooling (aapt2/bundletool/apksig/analytics-grpc) — NOT shipped in published core/compose-ui artifacts or the app runtime.
-    configurations.classpath {
-        resolutionStrategy {
-            force(
-                "io.netty:netty-buffer:4.1.132.Final",
-                "io.netty:netty-codec:4.1.132.Final",
-                "io.netty:netty-codec-http:4.1.132.Final",
-                "io.netty:netty-codec-http2:4.1.132.Final",
-                "io.netty:netty-codec-socks:4.1.132.Final",
-                "io.netty:netty-common:4.1.132.Final",
-                "io.netty:netty-handler:4.1.132.Final",
-                "io.netty:netty-handler-proxy:4.1.132.Final",
-                "io.netty:netty-resolver:4.1.132.Final",
-                "io.netty:netty-transport:4.1.132.Final",
-                "io.netty:netty-transport-native-unix-common:4.1.132.Final",
-                "org.bouncycastle:bcprov-jdk18on:1.84",
-                "org.bouncycastle:bcpkix-jdk18on:1.84",
-                "org.bouncycastle:bcutil-jdk18on:1.84",
-                "com.google.protobuf:protobuf-java:3.25.5",
-                "com.google.protobuf:protobuf-java-util:3.25.5",
-                "commons-io:commons-io:2.15.1", // >=2.14.0 patches CVE-2024-47554; 2.15.1 is the highest already on the classpath (avoids a downgrade)
-                "org.apache.commons:commons-compress:1.26.0",
-                "org.bitbucket.b_c:jose4j:0.9.6",
-                "org.jdom:jdom2:2.0.6.1",
-            )
-        }
-    }
-}
-
 // Detekt needs AGP/KGP classes on the root classpath to configure Android module tasks.
 plugins {
     alias(libs.plugins.android.application) apply false


### PR DESCRIPTION
## Why

The 27+ Dependabot alerts that #34 forced patched versions for were all **build-time AGP/lint tooling transitives** that never ship in the published `:core`/`:compose-ui` artifacts. They're now resolved at the source by #36, which scopes the dependency submission to the published runtime classpaths — the Dependabot dashboard is at **0 open alerts**.

With the buildscript classpath no longer part of the submitted graph, the `buildscript { … force(…) }` block from #34 silences nothing. Keeping it only adds risk: on a future AGP upgrade a pin can silently **downgrade**/conflict with AGP's bundled tooling (already observed with `commons-io` 2.15.1 → 2.14.0).

## Change

Reverts the force block (`c729827`). `build.gradle.kts` returns to imports → `plugins`, 31 lines removed.

## Verification

- `./gradlew build` — **green** without the block.
- Dependabot: 0 open alerts (unaffected — those deps aren't in the scoped graph either way).

Reverts c729827d57d823af7997c3a7e7c337478c668092.