### PR TITLE
Add tag-triggered Maven Central release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the GitHub release
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    environment:
+      name: maven-central
+      url: https://central.sonatype.com/artifact/io.github.ivan-magda/kotlin-textmate-core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Verify tag matches VERSION_NAME
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(grep -E '^VERSION_NAME=' gradle.properties | cut -d= -f2-)"
+          echo "tag=$tag version=$version"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Tag v$tag does not match VERSION_NAME=$version in gradle.properties"
+            exit 1
+          fi
+          case "$version" in
+            *-SNAPSHOT) echo "::error::Refusing to release a SNAPSHOT version"; exit 1 ;;
+          esac
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Publish and release to Maven Central
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+Releases publish `kotlin-textmate-core` and `kotlin-textmate-compose` to Maven Central.
+Pushing a `v*` tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
+which publishes the tagged commit and creates a GitHub release. The publish job waits for
+manual approval on the protected `maven-central` environment.
+
+## One-time setup
+
+Configure these in the repository's `maven-central` environment
+(Settings → Environments → `maven-central`):
+
+1. Add a **required reviewer** so the publish waits for a click.
+2. Add four **environment secrets**:
+
+   | Secret | Value |
+   |---|---|
+   | `MAVEN_CENTRAL_USERNAME` | Central Portal user token name |
+   | `MAVEN_CENTRAL_PASSWORD` | Central Portal user token value |
+   | `SIGNING_KEY` | ASCII-armored GPG private key: `gpg --export-secret-keys --armor <KEY_ID>` |
+   | `SIGNING_PASSWORD` | passphrase for that key |
+
+   Generate the Central Portal token at <https://central.sonatype.com> → Account → Generate User Token.
+
+## Cutting a release
+
+1. Make sure `main` is green.
+2. Set the release version in `gradle.properties` (`VERSION_NAME`, drop `-SNAPSHOT`) and update the install coordinates in `README.md`.
+3. Commit as `Release X.Y.Z`.
+4. Tag and push:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release X.Y.Z"
+   git push origin main vX.Y.Z
+   ```
+
+5. Approve the `maven-central` deployment in the Actions run. The workflow verifies the tag matches `VERSION_NAME`, refuses `-SNAPSHOT`, publishes, and creates the GitHub release.
+6. Watch the deployment at <https://central.sonatype.com/publishing/deployments>. Sync to `repo1.maven.org` lands within minutes to a couple of hours.
+7. Open the next development version: set `VERSION_NAME` to the next `-SNAPSHOT`, commit as `Prepare next development version`, and push.
+
+## Notes
+
+- `VERSION_NAME` is the single source of truth; `TextMateGrammar.VERSION` is generated from it at build time.
+- The publish is irreversible — Maven Central coordinates cannot be reused or unpublished.
+- To publish from a machine instead of CI, run `./gradlew publishAndReleaseToMavenCentral` with the same credentials as local Gradle properties.


### PR DESCRIPTION
Automates Maven Central releases so they no longer run from a dev machine.

## How it works

Pushing a `v*` tag triggers `.github/workflows/release.yml`, which publishes the tagged commit via `publishAndReleaseToMavenCentral` and creates a GitHub release with generated notes.

- **Gated.** The publish job runs in a protected `maven-central` environment, so the irreversible step waits for a required reviewer's approval.
- **Guarded.** Before publishing, the workflow verifies the tag matches `VERSION_NAME` and refuses any `-SNAPSHOT` version.
- **In-memory signing.** Credentials and the GPG key come from environment secrets, mapped to the `ORG_GRADLE_PROJECT_*` properties the vanniktech plugin reads.

`RELEASING.md` documents the one-time environment setup (required reviewer + four secrets) and the per-release steps.

## Before the first CI release

Configure the `maven-central` environment in repo settings:
- Add a required reviewer.
- Add secrets `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD` (details in `RELEASING.md`).

## Validation

`actionlint` passes on the workflow.
